### PR TITLE
fix: add double quotes for minecraft:custom_name and minecraft:lore sub-attributes

### DIFF
--- a/Knowledge Book/data/knowledge_book/loot_table/knowledge_book.json
+++ b/Knowledge Book/data/knowledge_book/loot_table/knowledge_book.json
@@ -28,14 +28,14 @@
                 "minecraft:max_stack_size": 1,
                 "minecraft:item_model": "minecraft:knowledge_book",
                 "minecraft:custom_name": {
-                  text: "Knowledge Book",
-                  italic: false
+                  "text": "Knowledge Book",
+                  "italic": false
                 },
                 "minecraft:lore": [
                   {
-                    text: "Unlock all recipes",
-                    italic: false,
-                    color: "gray"
+                    "text": "Unlock all recipes",
+                    "italic": false,
+                    "color": "gray"
                   }
                 ]
               }

--- a/Knowledge Book/data/knowledge_book/recipe/knowledge_book.json
+++ b/Knowledge Book/data/knowledge_book/recipe/knowledge_book.json
@@ -21,14 +21,14 @@
             "minecraft:max_stack_size": 1,
             "minecraft:item_model": "minecraft:knowledge_book",
             "minecraft:custom_name": {
-                text: "Knowledge Book",
-                italic: false
+                "text": "Knowledge Book",
+                "italic": false
             },
             "minecraft:lore": [
                 {
-                    text: "Unlock all recipes",
-                    italic: false,
-                    color: "gray"
+                    "text": "Unlock all recipes",
+                    "italic": false,
+                    "color": "gray"
                 }
             ]
         }


### PR DESCRIPTION
fix: #9